### PR TITLE
[Fix / Service] 업적, 이모지 null 처리 로직 수정 close #57

### DIFF
--- a/src/user-achievement/dto/get.user.achievements.dto.ts
+++ b/src/user-achievement/dto/get.user.achievements.dto.ts
@@ -1,4 +1,3 @@
 export class GetUserAchievementsDto {
   userId: number;
-  isSelected: boolean;
 }

--- a/src/user-achievement/user-achievement.service.spec.ts
+++ b/src/user-achievement/user-achievement.service.spec.ts
@@ -53,24 +53,21 @@ describe('UserAchievemetService', () => {
     //user[0]친구가 : selected와 acheieved, unacheieved가 전부 있음
     const mixedRequest: GetUserAchievementsDto = {
       userId: achievementSelectedWithUser.id,
-      isSelected: false,
     };
     //user[1]친구가 : selected가 없는상태
     const unSelectedRequest: GetUserAchievementsDto = {
       userId: noAchievementSelectedWithUser.id,
-      isSelected: false,
     };
     //user[2]친구가: achieved도 없는상태
     const noEmojiRequest: GetUserAchievementsDto = {
       userId: userWithOutAchievement.id,
-      isSelected: false,
     };
     //없는 유저에 대해서 접근하는 테스트 코드가 필요하다 언제? getUserDetail이 로그인이구현되는 그때
 
     //When
-    const selectedCase = await service.getUserAchievements(mixedRequest);
-    const nonSelectedCase = await service.getUserAchievements(unSelectedRequest);
-    const noEmojiCase = await service.getUserAchievements(noEmojiRequest);
+    const selectedCase = await service.getUserAchievementsAll(mixedRequest);
+    const nonSelectedCase = await service.getUserAchievementsAll(unSelectedRequest);
+    const noEmojiCase = await service.getUserAchievementsAll(noEmojiRequest);
 
     //then
     expect(selectedCase.achievements.length).toBe(testData.achievements.length);
@@ -99,32 +96,27 @@ describe('UserAchievemetService', () => {
 
     const selectedRequest: GetUserAchievementsDto = {
       userId: achievementSelectedWithUser.id,
-      isSelected: true,
     };
 
     const unSelectedRequest: GetUserAchievementsDto = {
       userId: nonAchievementSelectedWithUser.id,
-      isSelected: true,
     };
 
     const nonSelectedRequest: GetUserAchievementsDto = {
       userId: userWithOutAchievement.id,
-      isSelected: true,
     };
 
     const reverseSelectedRequest: GetUserAchievementsDto = {
       userId: userWithReversedAchievement.id,
-      isSelected: true,
     }
     const mixedSelectedRequest: GetUserAchievementsDto = {
       userId: userWithMixedAchievement.id,
-      isSelected: true,
     }
-    const selectedCase = await service.getUserAchievements(selectedRequest);
-    const unSelectedCase = await service.getUserAchievements(unSelectedRequest);
-    const noEmojiCase = await service.getUserAchievements(nonSelectedRequest);
-    const reversedCase = await service.getUserAchievements(reverseSelectedRequest);
-    const mixedCase = await service.getUserAchievements(mixedSelectedRequest);
+    const selectedCase = await service.getUserAchievementsSelected(selectedRequest);
+    const unSelectedCase = await service.getUserAchievementsSelected(unSelectedRequest);
+    const noEmojiCase = await service.getUserAchievementsSelected(nonSelectedRequest);
+    const reversedCase = await service.getUserAchievementsSelected(reverseSelectedRequest);
+    const mixedCase = await service.getUserAchievementsSelected(mixedSelectedRequest);
 
     //then
     expect(selectedCase.achievements.length).toBe(3);

--- a/src/user-achievement/user-achievement.service.ts
+++ b/src/user-achievement/user-achievement.service.ts
@@ -20,12 +20,36 @@ export class UserAchievementService {
     @InjectRepository(Achievemet)
     private achievementRepository: Repository<Achievemet>,
   ) {}
-
-  //get user achievements
-  async getUserAchievements(
+  async getUserAchievementsAll(
     getDto: GetUserAchievementsDto,
   ): Promise<UserAchievementsDto> {
-    if (getDto.isSelected == true) {
+      //achieved이고 selected되지 않은 업적 return
+      const allAchievement = await this.achievementRepository.find();
+      const userAchievement = await this.userAchievementRepository.find({
+        where: { user: { id: getDto.userId } },
+      });
+      const achievements: UserAchievementDto[] = [];
+      const status = new UserCollectablesStatus(allAchievement.length);
+      status.setStatus(userAchievement); // userAchievement 에 있는 status 를 allAchievement 에 변경
+
+      for (const c of allAchievement) {
+        achievements.push({
+          id: c.id,
+          name: c.name,
+          status: status.getStatus(c.id),
+        });
+      }
+
+      const responseDto: UserAchievementsDto = {
+        achievements: achievements,
+      };
+      return responseDto;
+  }
+
+  //get user achievements
+  async getUserAchievementsSelected(
+    getDto: GetUserAchievementsDto,
+  ): Promise<UserAchievementsDto> {
       //achieved이고 selected된 업적 return
       const selectAchievement = await this.userAchievementRepository.find({
         where: { user: { id: getDto.userId }, selectedOrder: Not(IsNull()) },
@@ -42,28 +66,6 @@ export class UserAchievementService {
         achievements: achievements,
       };
       return responseDto;
-    }
-    //achieved이고 selected되지 않은 업적 return
-    const allAchievement = await this.achievementRepository.find();
-    const userAchievement = await this.userAchievementRepository.find({
-      where: { user: { id: getDto.userId } },
-    });
-    const achievements: UserAchievementDto[] = [];
-    const status = new UserCollectablesStatus(allAchievement.length);
-    status.setStatus(userAchievement); // userAchievement 에 있는 status 를 allAchievement 에 변경
-
-    for (const c of allAchievement) {
-      achievements.push({
-        id: c.id,
-        name: c.name,
-        status: status.getStatus(c.id),
-      });
-    }
-
-    const responseDto: UserAchievementsDto = {
-      achievements: achievements,
-    };
-    return responseDto;
   }
 
   //patch user achievement Patch 가 old 랑 to_change로 저장하고 return 하는 로직을 구현해야한다

--- a/src/user-emoji/dto/get.user.emojis.dto.ts
+++ b/src/user-emoji/dto/get.user.emojis.dto.ts
@@ -1,4 +1,3 @@
 export class GetUserEmojisDto {
   userId: number;
-  isSelected: boolean;
 }

--- a/src/user-emoji/user-emoji.service.spec.ts
+++ b/src/user-emoji/user-emoji.service.spec.ts
@@ -52,24 +52,21 @@ describe('UserEmojiService', () => {
     //user[0]친구가 : selected와 acheieved, unacheieved가 전부 있음
     const mixedRequest: GetUserEmojisDto = {
       userId: emojiSelectedWithUser.id,
-      isSelected: false,
     };
     //user[1]친구가 : selected가 없는상태
     const unSelectedRequest: GetUserEmojisDto = {
       userId: nonEmojiSelectedWithUser.id,
-      isSelected: false,
     };
     //user[2]친구가: achieved도 없는상태
     const noEmojiRequest: GetUserEmojisDto = {
       userId: userWithOutEmoji.id,
-      isSelected: false,
     };
     //없는 유저에 대해서 접근하는 테스트 코드가 필요하다 언제? getUserDetail이 로그인이구현되는 그때
 
     //When
-    const selectedCase = await service.getUseremojis(mixedRequest);
-    const nonSelectedCase = await service.getUseremojis(unSelectedRequest);
-    const noEmojiCase = await service.getUseremojis(noEmojiRequest);
+    const selectedCase = await service.getUseremojisAll(mixedRequest);
+    const nonSelectedCase = await service.getUseremojisAll(unSelectedRequest);
+    const noEmojiCase = await service.getUseremojisAll(noEmojiRequest);
 
     //then
     expect(selectedCase.emojis.length).toBe(testData.emojis.length);
@@ -98,32 +95,27 @@ describe('UserEmojiService', () => {
 
     const selectedRequest: GetUserEmojisDto = {
       userId: emojiSelectedWithUser.id,
-      isSelected: true,
     };
 
     const unSelectedRequest: GetUserEmojisDto = {
       userId: nonEmojiSelectedWithUser.id,
-      isSelected: true,
     };
 
     const nonSelectedRequest: GetUserEmojisDto = {
       userId: userWithOutEmoji.id,
-      isSelected: true,
     };
 
     const reverseSelectedRequest: GetUserEmojisDto = {
       userId: userWithReversedEmoji.id,
-      isSelected: true,
     }
     const mixedSelectedRequest: GetUserEmojisDto = {
       userId: userWithMixedEmoji.id,
-      isSelected: true,
     }
-    const selectedCase = await service.getUseremojis(selectedRequest);
-    const unSelectedCase = await service.getUseremojis(unSelectedRequest);
-    const noEmojiCase = await service.getUseremojis(nonSelectedRequest);
-    const reversedCase = await service.getUseremojis(reverseSelectedRequest);
-    const mixedCase = await service.getUseremojis(mixedSelectedRequest);
+    const selectedCase = await service.getUseremojisSelected(selectedRequest);
+    const unSelectedCase = await service.getUseremojisSelected(unSelectedRequest);
+    const noEmojiCase = await service.getUseremojisSelected(nonSelectedRequest);
+    const reversedCase = await service.getUseremojisSelected(reverseSelectedRequest);
+    const mixedCase = await service.getUseremojisSelected(mixedSelectedRequest);
 
     //then
     expect(selectedCase.emojis.length).toBe(4);

--- a/src/user-emoji/user-emoji.service.ts
+++ b/src/user-emoji/user-emoji.service.ts
@@ -17,25 +17,8 @@ export class UserEmojiService {
     @InjectRepository(Emoji)
     private emojiRepository: Repository<Emoji>,
   ) {}
-  //getUseremojis함수
-  async getUseremojis(getDto: GetUserEmojisDto): Promise<UseremojisDto> {
-    if (getDto.isSelected) {
-      const selectedEmoji = await this.userEmojiRepository.find({
-        where: { user: { id: getDto.userId }, selectedOrder: Not(IsNull()) },
-      });
-      const emojis: UserEmojiDto[] = [null, null, null, null];
-      for (const userEmoji of selectedEmoji) {
-        emojis[userEmoji.selectedOrder] = {
-          id: userEmoji.emoji.id,
-          name: userEmoji.emoji.name,
-          status: CollectableStatus.SELECTED,
-        };
-      }
-      const responseDto: UseremojisDto = {
-        emojis: emojis,
-      };
-      return responseDto;
-    }
+
+  async getUseremojisAll(getDto: GetUserEmojisDto): Promise<UseremojisDto> {
     const allEmoji = await this.emojiRepository.find();
     const userEmoji = await this.userEmojiRepository.find({
       where: { user: { id: getDto.userId } },
@@ -54,6 +37,25 @@ export class UserEmojiService {
       emojis: emojis,
     };
     return responseDto;
+  }
+
+  //getUseremojis함수
+  async getUseremojisSelected(getDto: GetUserEmojisDto): Promise<UseremojisDto> {
+      const selectedEmoji = await this.userEmojiRepository.find({
+        where: { user: { id: getDto.userId }, selectedOrder: Not(IsNull()) },
+      });
+      const emojis: UserEmojiDto[] = [null, null, null, null];
+      for (const userEmoji of selectedEmoji) {
+        emojis[userEmoji.selectedOrder] = {
+          id: userEmoji.emoji.id,
+          name: userEmoji.emoji.name,
+          status: CollectableStatus.SELECTED,
+        };
+      }
+      const responseDto: UseremojisDto = {
+        emojis: emojis,
+      };
+      return responseDto;
   }
 
   //patchUseremojis함수


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> 
#57
#14
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 업적, 이모지 조회 시 고정값 크기의 배열로 반환 (업적 3, 이모지 4)
- 빈 칸은 null 처리
- 변경 요청시 들어온 순서에 따라 저장. 조회시에는 변경 요청때 했던대로 반환
- isSelected 여부에 따른 함수 분리