### PR TITLE
[fix] 경험치 오르는 문제 해결 #196

### DIFF
--- a/src/domain/user-game/user-game.service.ts
+++ b/src/domain/user-game/user-game.service.ts
@@ -167,13 +167,13 @@ export class UserGameService {
       [GAMERESULT_TIE]: Number(process.env.GAME_TIE_EXP),
     };
 
-    const exp = expMapping[userGame.result];
-    const beforeExp =
+    const increasedExp = expMapping[userGame.result];
+    const userExp =
       user.exp - (user.level - 1) * Number(process.env.LEVEL_UP_EXP);
 
     return new GetUserGameExpResponseDto(
-      beforeExp,
-      exp,
+      userExp - increasedExp,
+      increasedExp,
       Number(process.env.LEVEL_UP_EXP),
     );
   }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue --> #196
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
경험치 오르는 화면이 이제 정상적으로 그려집니다.

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 이미 경험치가 오른 뒤에 exp 요청이 가므로, beforeExp를 구할 때 현재 exp에서 오른 만큼 한 번 빼고 보여줘야 하는 문제가 있었습니다.
- 그렇게 수정함

## Etc
