### PR TITLE
[Fix] 랭킹 조회시 순위권 밖일 경우 undefind를 참조하는 문제 수정 #261

### DIFF
--- a/src/domain/rank/rank.repository.ts
+++ b/src/domain/rank/rank.repository.ts
@@ -80,7 +80,7 @@ export class RankRepository {
       await this.repository.query(query, [seasonId, userId])
     )[0];
 
-    const ranking = Number(userRank.ranking);
+    const ranking = Number(userRank?.ranking);
 
     return ranking;
   }


### PR DESCRIPTION
## Issue
+ Issue Number: <!-- #issue -->
#261 
+ PR Type: `fix`

## Summary
<!-- 해당 기능에 대한 요약글 -->
- 유저 랭킹 조회시 에러가 발생하는 부분을 수정했습니다

## Detail
<!-- 해당 기능에 대한 상세 요소-->
- 랭킹 조회시 순위권 밖인 경우 랭킹을 반환하지 않는 부분에서 undefind를 참조하는 문제를 수정했습니다
```
  async findRankingByUserIdAndSeasonId(
    userId: number,
    seasonId: number,
  ): Promise<number> {
    const query = `
    SELECT user_id, ranking
    FROM (
      SELECT user_id, ROW_NUMBER() OVER (ORDER BY ladder_point DESC, updated_at ASC) as ranking
      FROM "rank"
      WHERE (season_id = $1 AND ladder_point >= ${process.env.DOCTOR_CUT})
      LIMIT 200
    ) ranking
    WHERE user_id = $2
  `;
    const userRank = (
      await this.repository.query(query, [seasonId, userId])
    )[0];

    const ranking = Number(userRank.ranking);  // userRank가 없는 경우 에러가 발생

    return ranking;
  }

```
